### PR TITLE
Add support for latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All variables in [default/main.yml](defaults/main.yml) can be overrided
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-|`prometheus_msteams_version`| 1.4.1| prometheus-msteams version to install|
+|`prometheus_msteams_version`| latest| prometheus-msteams version to install|
 |`prometheus_msteams_binary_local_dir`| ""| To allow to use local packages from controller machine instead of github packages|
 |`prometheus_msteams_template_local_dir`| ""| To allow to use local teams card template on controller machine than from github|
 |`prometheus_msteams_config_dir`| "/etc/prometheus_msteams"| Location to store server configs |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-prometheus_msteams_version: 1.4.1
+prometheus_msteams_version: latest
 
 prometheus_msteams_binary_local_dir: ""
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -17,6 +17,28 @@
     prometheus_msteams_systemd_version: "{{ __systemd_version.stdout_lines[0] | regex_replace('^systemd\\s(\\d+).*$', '\\1') }}"
 
 - block:
+    - name: Get latest release
+      uri:
+        url: "https://api.github.com/repos/prometheus-msteams/prometheus-msteams/releases/latest"
+        method: GET
+        return_content: true
+        status_code: 200
+        body_format: json
+        user: "{{ lookup('env', 'GH_USER') | default(omit) }}"
+        password: "{{ lookup('env', 'GH_TOKEN') | default(omit) }}"
+      no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+      register: _latest_release
+      until: _latest_release.status == 200
+      retries: 5
+
+    - name: "Set prometheus-msteams version to {{ _latest_release.json.tag_name[1:] }}"
+      set_fact:
+        prometheus_msteams_version: "{{ _latest_release.json.tag_name[1:] }}"
+  when:
+    - prometheus_msteams_version == "latest"
+    - prometheus_msteams_binary_local_dir | length == 0
+
+- block:
     - name: Get checksum list from github
       set_fact:
         _checksums: "{{ lookup('url', 'https://github.com/prometheus-msteams/prometheus-msteams/releases/download/v' + prometheus_msteams_version + '/shasum256.txt', wantlist=True) | list }}"


### PR DESCRIPTION
This PR adds support for downloading the latest version of prometheus-msteams, and is inspired by similar code from the cloudalchemy roles.

Many thanks for this excellent ansible role! Hope you will upload it to Galaxy soon, which is where it belongs :-)