### PR TITLE
Fix propagate locally distributed prometheus_msteams template card

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -48,7 +48,7 @@
     mode: 0755
     owner: root
     group: root
-  when: prometheus_msteams_binary_local_dir | length > 0
+  when: prometheus_msteams_template_local_dir | length > 0
 
 - name: Copy the prometheus_msteams systemd service file
   template:


### PR DESCRIPTION
Using `prometheus_msteams_binary_local_dir` without `prometheus_msteams_template_local_dir` or just `prometheus_msteams_template_local_dir` is not possible for the moment because of a wrong condition when deploying custom template card.

Context : 
I need to be able to deploy a prometheus-msteams package build for ARM architecture but the package is not provided in Release assets on [github](https://github.com/prometheus-msteams/prometheus-msteams/releases/tag/v1.5.0) (only amd64 available).

Example of inventory :
```
prometheus_msteams_binary_local_dir: "{{ playbook_dir }}/files/prometheus-msteams-linux-arm64"
prometheus_msteams_web_listen_address: "0.0.0.0:2000"
prometheus_msteams_channels:
  - common: "https://outlook.office.com/webhook/xxxx/aaa/bbb"
```

Error when executing playbook : 
```
TASK [slashpai.ansible_prometheus_msteams : propagate locally distributed prometheus_msteams template card] *****************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
fatal: [dummyserver]: FAILED! => {"changed": false, "msg": "Could not find or access '/default-message-card.tmpl' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
```

Workaround : 
- Copy locally a template card (in {{ playbook_dir }}/files/prometheus-msteams-template-card)
- Adapt the inventory like this : 
```
prometheus_msteams_binary_local_dir: "{{ playbook_dir }}/files/prometheus-msteams-linux-arm64"
prometheus_msteams_template_local_dir: "{{ playbook_dir }}/files/prometheus-msteams-template-card"
prometheus_msteams_web_listen_address: "0.0.0.0:2000"
prometheus_msteams_channels:
  - common: "https://outlook.office.com/webhook/xxxx/aaa/bbb"
```